### PR TITLE
Update ViewKt.kt

### DIFF
--- a/qmui/src/main/java/com/qmuiteam/qmui/kotlin/ViewKt.kt
+++ b/qmui/src/main/java/com/qmuiteam/qmui/kotlin/ViewKt.kt
@@ -8,11 +8,11 @@ import com.qmuiteam.qmui.skin.QMUISkinValueBuilder
 fun throttleClick(wait: Long = 200, block: ((View) -> Unit)): View.OnClickListener {
 
     return View.OnClickListener { v ->
-        val current = System.currentTimeMillis()
-        val lastClickTime = (v.getTag(R.id.qmui_click_timestamp) as? Int) ?: 0
+        val current:Long = System.currentTimeMillis()
+        val lastClickTime = (v.getTag(R.id.qmui_click_timestamp) as? Long) ?: 0
         if (current - lastClickTime > wait) {
-            block(v)
             v.setTag(R.id.qmui_click_timestamp, current)
+            block(v)
         }
     }
 }


### PR DESCRIPTION
1. `System.currentTimeMillis`返回Long，写入Tag后将无法专为Int，导致if块持续进入，仿连触失效
2.防止连续点击，如果block执行时间过长，setTag将无法执行